### PR TITLE
Patch 1

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,7 @@ export const config = {
   },
   swap: {
     verbose_log: false,
-    prio_fee_max_lamports: 1000000, // 0.001 SOL
+    prio_fee_max_lamports: 1000000, // 0.001 SOL // max priority fee you are willing to pay. Too low will fail swaps.
     prio_level: "veryHigh", // If you want to land transaction fast, set this to use `veryHigh`. You will pay on average higher priority fee.
     amount: "10000000", //0.01 SOL
     slippageBps: "200", // 2%
@@ -23,7 +23,7 @@ export const config = {
   },
   sell: {
     price_source: "dex", // dex=Dexscreener,jup=Jupiter Agregator (Dex is most accurate and Jupiter is always used as fallback)
-    prio_fee_max_lamports: 1000000, // 0.001 SOL
+    prio_fee_max_lamports: 1000000, // 0.001 SOL // max priority fee you are willing to pay. Too low will fail swaps.
     prio_level: "veryHigh", // If you want to land transaction fast, set this to use `veryHigh`. You will pay on average higher priority fee.
     slippageBps: "200", // 2%
     auto_sell: false, // If set to true, stop loss and take profit triggers automatically when set.

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -217,12 +217,10 @@ export async function createSwapTransaction(solMint: string, tokenMint: string):
           // This will set an optimized slippage to ensure high success rate
           maxBps: 300, // Make sure to set a reasonable cap here to prevent MEV
         },
-        prioritizationFeeLamports: {
-          priorityLevelWithMaxLamports: {
-            maxLamports: config.swap.prio_fee_max_lamports,
-            priorityLevel: config.swap.prio_level,
-          },
-        },
+        // Sets max priority fee you are willing to pay.
+        // Make sure to not set too low or swaps will fail 
+        // Setting too high will eat away at profits.
+        prioritizationFeeLamports: config.swap.prio_fee_max_lamports,
       }),
       {
         headers: {
@@ -642,12 +640,10 @@ export async function createSellTransaction(solMint: string, tokenMint: string, 
           // This will set an optimized slippage to ensure high success rate
           maxBps: 300, // Make sure to set a reasonable cap here to prevent MEV
         },
-        prioritizationFeeLamports: {
-          priorityLevelWithMaxLamports: {
-            maxLamports: config.sell.prio_fee_max_lamports,
-            priorityLevel: config.sell.prio_level,
-          },
-        },
+        // Sets max priority fee you are willing to pay.
+        // Make sure to not set too low or swaps will fail 
+        // Setting too high will eat away at profits.
+        prioritizationFeeLamports: config.swap.prio_fee_max_lamports,
       }),
       {
         headers: {


### PR DESCRIPTION
According to Jupiter Station swap API docs (https://station.jup.ag/api-v6/post-swap), `prioritizationFeeLamports` is to be an integer. With the former value of the variable, swaps kept failing with error code 422: Unprocessable Entity - Failed to deserialize the JSON body into the target type. 
I have updated it to be an integer, set to the max priority fee the user is willing to pay, sourced from `config.ts`.